### PR TITLE
Use shell-words to split editor command

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,7 @@ ui = { package = "requestty-ui", path = "./requestty-ui", version = "=0.4.1" }
 macro = { package = "requestty-macro", path = "./requestty-macro", optional = true, version = "=0.4.1" }
 
 tempfile = "3"
+shell-words = "1"
 
 smallvec = { version = "1.8", optional = true }
 

--- a/src/question/editor.rs
+++ b/src/question/editor.rs
@@ -34,17 +34,20 @@ impl<'a> Default for Editor<'a> {
 }
 
 fn get_editor() -> Command {
-    Command::new(
-        env::var_os("VISUAL")
-            .or_else(|| env::var_os("EDITOR"))
-            .unwrap_or_else(|| {
-                if cfg!(windows) {
-                    "notepad".into()
-                } else {
-                    "vim".into()
-                }
-            }),
-    )
+    let editor_command = env::var_os("VISUAL")
+        .or_else(|| env::var_os("EDITOR"))
+        .unwrap_or_else(|| {
+            if cfg!(windows) {
+                "notepad".into()
+            } else {
+                "vim".into()
+            }
+        });
+
+    let parts = shell_words::split(editor_command.to_str().unwrap()).unwrap();
+    let mut command = Command::new(&parts[0]);
+    command.args(&parts[1..]);
+    command
 }
 
 struct EditorPrompt<'a, 'e> {


### PR DESCRIPTION
Hey there! I love this library. I noticed a bug in the editor code, though, that I thought I might be able to fix for you.

My `EDITOR` environment variable is set to `subl -w` because Sublime Text needs a `-w` to wait until the window is closed. However the code in requestty assumed `EDITOR` was just a single executable and thus I would get a `no such file or directory` error when the command tried to execute.

To handle this I've added [shell-words](https://crates.io/crates/shell-words) to handle splitting (since splitting commands with arguments and quotes is non-trivial) and this seems to work.

I can run my program with `EDITOR=vim` and it works as well as `EDITOR="subl -w"` and it works. So this seems to still work for the default case but now also supports environments where users have arguments baked into their `EDITOR` variable.